### PR TITLE
feat: add py2app packaging infrastructure with .app and .dmg support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,11 @@ bin/
 obj/
 out/
 
+# py2app build artifacts
+*.app
+*.dmg
+resources/*.icns
+
 # Logs
 logs/
 *.log

--- a/README.md
+++ b/README.md
@@ -310,6 +310,153 @@ FEW_SHOT_EXAMPLES = {
 
 ---
 
+## 打包與發布
+
+### 建置 macOS .app
+
+使用 py2app 打包為獨立應用程式：
+
+```bash
+# 1. 確保已啟動虛擬環境
+source venv/bin/activate
+
+# 2. 執行自動化建置腳本
+./build.sh
+
+# 建置產物：dist/MacDesktopWidget.app
+```
+
+**建置腳本功能：**
+- 自動安裝 py2app 依賴
+- 清理舊建置檔案
+- 執行 `python setup.py py2app`
+- 驗證建置結果與檔案大小
+- 檢查程式碼簽章狀態
+
+### 建立 DMG 安裝包
+
+將 .app 打包為 DMG 發布檔：
+
+```bash
+# 執行 DMG 建立腳本
+./create_dmg.sh
+
+# 產出：dist/MacDesktopWidget-1.0.0.dmg
+```
+
+**DMG 建立流程：**
+1. 建立臨時 DMG 映像檔
+2. 掛載並配置內容（複製 .app + Applications 捷徑）
+3. 壓縮為唯讀 DMG（zlib-level=9）
+4. 自動清理暫存檔案
+
+### 程式碼簽章（選配）
+
+為應用程式加上數位簽章以通過 Gatekeeper：
+
+```bash
+# 查看可用的簽章身份
+security find-identity -v -p codesigning
+
+# 簽章 .app
+codesign --deep --force --sign "Developer ID Application: Your Name" \
+  dist/MacDesktopWidget.app
+
+# 驗證簽章
+codesign -dvvv dist/MacDesktopWidget.app
+spctl -a -t exec -vv dist/MacDesktopWidget.app
+```
+
+### 公證（Notarization）
+
+提交至 Apple 進行公證（需付費開發者帳號）：
+
+```bash
+# 1. 將 DMG 上傳至 Apple 公證服務
+xcrun notarytool submit dist/MacDesktopWidget-1.0.0.dmg \
+  --apple-id "your-email@example.com" \
+  --team-id "YOUR_TEAM_ID" \
+  --password "app-specific-password" \
+  --wait
+
+# 2. 公證完成後，附加公證票據
+xcrun stapler staple dist/MacDesktopWidget-1.0.0.dmg
+
+# 3. 驗證公證狀態
+xcrun stapler validate dist/MacDesktopWidget-1.0.0.dmg
+```
+
+### 發布檔案結構
+
+```
+dist/
+├── MacDesktopWidget.app          # macOS 應用程式
+│   ├── Contents/
+│   │   ├── MacOS/                # 執行檔
+│   │   ├── Resources/            # 資源檔案
+│   │   ├── Frameworks/           # Python 框架與依賴
+│   │   └── Info.plist            # App 元資料
+└── MacDesktopWidget-1.0.0.dmg    # 發布用安裝包 (~50MB)
+```
+
+### 自訂應用程式圖示
+
+建立或準備 .icns 圖示檔：
+
+```bash
+# 方法 1: 使用 iconutil（需準備 iconset 資料夾）
+mkdir resources/AppIcon.iconset
+# 將不同尺寸的 PNG 放入 iconset/
+iconutil -c icns resources/AppIcon.iconset -o resources/icon.icns
+
+# 方法 2: 使用線上工具
+# https://cloudconvert.com/png-to-icns
+# 下載後放置於 resources/icon.icns
+
+# 重新建置以套用圖示
+./build.sh
+```
+
+### 建置參數調整
+
+編輯 `setup.py` 以自訂打包行為：
+
+```python
+OPTIONS = {
+    'iconfile': 'resources/icon.icns',     # 應用程式圖示
+    'LSUIElement': False,                  # False=顯示在 Dock, True=背景執行
+    'optimize': 2,                         # Python 最佳化等級 (0-2)
+    'strip': True,                         # 移除除錯符號以減小檔案
+    'excludes': ['tkinter', 'matplotlib'], # 排除不需要的模組
+}
+```
+
+### 疑難排解
+
+**問題：無法開啟應用程式（已損毀）**
+```bash
+# 清除 macOS 隔離屬性
+xattr -cr dist/MacDesktopWidget.app
+```
+
+**問題：建置失敗，缺少模組**
+```bash
+# 確保所有依賴已安裝
+pip install -e ".[macos]"
+pip list | grep -E "PyQt6|psutil|aiohttp"
+```
+
+**問題：DMG 建立失敗**
+```bash
+# 確保有足夠磁碟空間（至少 500MB）
+df -h
+
+# 手動清理舊建置
+rm -rf build/ dist/
+```
+
+---
+
 ## 效能指標
 
 | 項目 | 數值 |
@@ -332,9 +479,10 @@ FEW_SHOT_EXAMPLES = {
 - [x] 台灣繁體中文 Prompt 優化
 - [x] Glassmorphism UI
 - [x] 單元測試套件 (85%+ 覆蓋)
+- [x] py2app 打包腳本 (.app + .dmg)
 - [ ] 使用者設定介面
 - [ ] 通知中心整合
-- [ ] 自動化部署腳本
+- [ ] Apple 開發者簽章與公證
 
 ---
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Build script for MacDesktopWidget using py2app
+# Usage: ./build.sh
+
+set -e  # Exit on error
+
+echo "======================================"
+echo "MacDesktopWidget Build Script"
+echo "======================================"
+echo ""
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Check if running on macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo -e "${RED}Error: This script must run on macOS${NC}"
+    exit 1
+fi
+
+# Check Python version
+PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+echo -e "${GREEN}Python version: $PYTHON_VERSION${NC}"
+
+# Check if virtual environment is activated
+if [[ -z "$VIRTUAL_ENV" ]]; then
+    echo -e "${YELLOW}Warning: Virtual environment not activated${NC}"
+    echo "Activating venv..."
+    if [ -d "venv" ]; then
+        source venv/bin/activate
+    else
+        echo -e "${RED}Error: venv not found. Run: python3 -m venv venv${NC}"
+        exit 1
+    fi
+fi
+
+# Install/update py2app
+echo ""
+echo -e "${GREEN}Installing py2app...${NC}"
+pip install --upgrade py2app setuptools wheel
+
+# Clean previous builds
+echo ""
+echo -e "${GREEN}Cleaning previous builds...${NC}"
+rm -rf build dist
+
+# Create resources directory if it doesn't exist
+mkdir -p resources
+
+# Generate a simple icon if it doesn't exist (optional)
+# Users can replace resources/icon.icns with their own icon
+if [ ! -f "resources/icon.icns" ]; then
+    echo -e "${YELLOW}Note: resources/icon.icns not found. App will use default icon.${NC}"
+    echo "To add custom icon: Place your .icns file at resources/icon.icns"
+fi
+
+# Build the app
+echo ""
+echo -e "${GREEN}Building MacDesktopWidget.app...${NC}"
+python3 setup.py py2app
+
+# Verify build
+if [ -d "dist/MacDesktopWidget.app" ]; then
+    echo ""
+    echo -e "${GREEN}✓ Build successful!${NC}"
+    echo ""
+    echo "App location: dist/MacDesktopWidget.app"
+
+    # Get app size
+    APP_SIZE=$(du -sh dist/MacDesktopWidget.app | awk '{print $1}')
+    echo "App size: $APP_SIZE"
+
+    # Test if app is signed (optional)
+    echo ""
+    echo "Checking code signature..."
+    codesign -dvvv dist/MacDesktopWidget.app 2>&1 | grep -E "Signature|Identifier" || echo "App is not signed"
+
+    echo ""
+    echo -e "${GREEN}Next steps:${NC}"
+    echo "1. Test the app: open dist/MacDesktopWidget.app"
+    echo "2. Create DMG: ./create_dmg.sh"
+    echo "3. (Optional) Sign the app: codesign --deep --force --sign 'Your Identity' dist/MacDesktopWidget.app"
+else
+    echo -e "${RED}✗ Build failed!${NC}"
+    echo "Check the error messages above."
+    exit 1
+fi
+
+echo ""
+echo "======================================"
+echo "Build Complete"
+echo "======================================"

--- a/create_dmg.sh
+++ b/create_dmg.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Create DMG installer for MacDesktopWidget
+# Usage: ./create_dmg.sh
+
+set -e  # Exit on error
+
+echo "======================================"
+echo "MacDesktopWidget DMG Creator"
+echo "======================================"
+echo ""
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Configuration
+APP_NAME="MacDesktopWidget"
+VERSION="1.0.0"
+DMG_NAME="${APP_NAME}-${VERSION}.dmg"
+VOLUME_NAME="${APP_NAME} ${VERSION}"
+APP_PATH="dist/${APP_NAME}.app"
+DMG_DIR="dist/dmg"
+FINAL_DMG="dist/${DMG_NAME}"
+
+# Check if app exists
+if [ ! -d "$APP_PATH" ]; then
+    echo -e "${RED}Error: ${APP_PATH} not found${NC}"
+    echo "Run ./build.sh first to build the app"
+    exit 1
+fi
+
+echo -e "${GREEN}Creating DMG installer...${NC}"
+
+# Clean previous DMG builds
+rm -rf "$DMG_DIR"
+rm -f "$FINAL_DMG"
+rm -f "dist/${APP_NAME}-temp.dmg"
+
+# Create DMG staging directory
+mkdir -p "$DMG_DIR"
+
+# Copy app to staging directory
+echo "Copying ${APP_NAME}.app to staging directory..."
+cp -R "$APP_PATH" "$DMG_DIR/"
+
+# Create Applications symlink for easy installation
+echo "Creating Applications symlink..."
+ln -s /Applications "$DMG_DIR/Applications"
+
+# Create .DS_Store for nice DMG layout (optional)
+# This would require a pre-configured .DS_Store file
+# For now, we'll create a simple DMG
+
+# Calculate required DMG size
+APP_SIZE=$(du -sm "$APP_PATH" | awk '{print $1}')
+DMG_SIZE=$((APP_SIZE + 50))  # Add 50MB buffer
+
+echo "App size: ${APP_SIZE}MB"
+echo "DMG size: ${DMG_SIZE}MB"
+
+# Create temporary DMG
+echo ""
+echo "Creating temporary DMG..."
+hdiutil create \
+    -volname "$VOLUME_NAME" \
+    -srcfolder "$DMG_DIR" \
+    -ov \
+    -format UDRW \
+    -size ${DMG_SIZE}m \
+    "dist/${APP_NAME}-temp.dmg"
+
+# Mount the temporary DMG
+echo "Mounting DMG..."
+MOUNT_DIR=$(hdiutil attach -readwrite -noverify -noautoopen "dist/${APP_NAME}-temp.dmg" | grep Volumes | awk '{print $3}')
+
+if [ -z "$MOUNT_DIR" ]; then
+    echo -e "${RED}Error: Failed to mount DMG${NC}"
+    exit 1
+fi
+
+echo "Mounted at: $MOUNT_DIR"
+
+# Set DMG background and icon positions (optional)
+# This requires additional tools like create-dmg or manual setup
+# For now, we'll create a basic DMG
+
+# Set custom DMG icon (optional)
+if [ -f "resources/dmg-icon.icns" ]; then
+    echo "Setting custom DMG icon..."
+    cp resources/dmg-icon.icns "$MOUNT_DIR/.VolumeIcon.icns"
+    SetFile -c icnC "$MOUNT_DIR/.VolumeIcon.icns"
+    SetFile -a C "$MOUNT_DIR"
+fi
+
+# Wait a moment for filesystem to settle
+sleep 2
+
+# Unmount the temporary DMG
+echo "Unmounting temporary DMG..."
+hdiutil detach "$MOUNT_DIR"
+
+# Convert to compressed read-only DMG
+echo ""
+echo "Compressing final DMG..."
+hdiutil convert \
+    "dist/${APP_NAME}-temp.dmg" \
+    -format UDZO \
+    -imagekey zlib-level=9 \
+    -o "$FINAL_DMG"
+
+# Clean up temporary files
+rm -f "dist/${APP_NAME}-temp.dmg"
+rm -rf "$DMG_DIR"
+
+# Verify final DMG
+if [ -f "$FINAL_DMG" ]; then
+    DMG_FINAL_SIZE=$(du -sh "$FINAL_DMG" | awk '{print $1}')
+    echo ""
+    echo -e "${GREEN}✓ DMG created successfully!${NC}"
+    echo ""
+    echo "DMG location: $FINAL_DMG"
+    echo "DMG size: $DMG_FINAL_SIZE"
+    echo ""
+    echo -e "${GREEN}Next steps:${NC}"
+    echo "1. Test the DMG: open $FINAL_DMG"
+    echo "2. (Optional) Notarize for distribution: xcrun notarytool submit $FINAL_DMG"
+    echo "3. Distribute to users"
+else
+    echo -e "${RED}✗ DMG creation failed!${NC}"
+    exit 1
+fi
+
+echo ""
+echo "======================================"
+echo "DMG Creation Complete"
+echo "======================================"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,71 @@
+"""
+py2app setup configuration for MacDesktopWidget.
+"""
+from setuptools import setup
+
+APP = ['src/python/main.py']
+DATA_FILES = []
+OPTIONS = {
+    'argv_emulation': False,
+    'iconfile': 'resources/icon.icns',  # Optional: Add app icon
+    'plist': {
+        'CFBundleName': 'MacDesktopWidget',
+        'CFBundleDisplayName': 'Mac Desktop Widget',
+        'CFBundleGetInfoString': 'macOS System Monitor with AI',
+        'CFBundleIdentifier': 'com.trionnemesis.macdesktopwidget',
+        'CFBundleVersion': '1.0.0',
+        'CFBundleShortVersionString': '1.0.0',
+        'NSHumanReadableCopyright': 'Copyright © 2024 trionnemesis. All rights reserved.',
+        'NSHighResolutionCapable': True,
+        'LSMinimumSystemVersion': '10.15.0',
+        'LSUIElement': False,  # Set to True to hide from Dock
+    },
+    'packages': [
+        'PyQt6',
+        'psutil',
+        'aiohttp',
+        'asyncio',
+        'pydantic',
+        'src.python.core',
+        'src.python.monitoring',
+        'src.python.ai',
+        'src.python.ui',
+    ],
+    'includes': [
+        'PyQt6.QtCore',
+        'PyQt6.QtGui',
+        'PyQt6.QtWidgets',
+    ],
+    'excludes': [
+        'tkinter',
+        'matplotlib',
+        'numpy',
+        'scipy',
+        'pandas',
+        'PIL',
+    ],
+    'resources': [
+        'src/python/ai/prompts/zh_tw_templates.py',
+    ],
+    'optimize': 2,
+    'strip': True,
+    'semi_standalone': False,
+    'site_packages': True,
+}
+
+setup(
+    name='MacDesktopWidget',
+    version='1.0.0',
+    description='macOS System Monitor with AI-powered suggestions',
+    author='trionnemesis',
+    app=APP,
+    data_files=DATA_FILES,
+    options={'py2app': OPTIONS},
+    setup_requires=['py2app'],
+    install_requires=[
+        'PyQt6>=6.4.0',
+        'psutil>=5.9.0',
+        'aiohttp>=3.8.0',
+        'pydantic>=2.0.0',
+    ],
+)


### PR DESCRIPTION
## Packaging Infrastructure

- Add setup.py with py2app configuration for macOS .app bundling
- Add build.sh automated build script with environment validation
- Add create_dmg.sh for creating distributable DMG installers
- Update .gitignore to exclude build artifacts (*.app, *.dmg, *.icns)

## Documentation Updates

- Add comprehensive "打包與發布" section to README.md
- Include step-by-step build instructions and DMG creation workflow
- Document code signing and Apple notarization process
- Add troubleshooting guide and customization options

## Key Features

- One-command app building: ./build.sh
- One-command DMG creation: ./create_dmg.sh
- Support for custom app icons (resources/icon.icns)
- Configurable build optimization (optimize=2, strip=True)
- Complete package dependency bundling
- Apple Gatekeeper preparation workflow